### PR TITLE
Bump to 0.2.0 and drop alpha release channel

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -105,7 +105,4 @@ jobs:
           gh release create v${{ needs.buildPluginArtifact.outputs.version }} \
             --draft \
             --title "v${{ needs.buildPluginArtifact.outputs.version }}" \
-            --notes "$(cat << 'EOM'
-          ${{ needs.buildPluginArtifact.outputs.changelog }}
-          EOM
-          )"
+            --generate-notes

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,15 @@
+# Developer notes
+
+## Changelog management
+
+* Bump plugin version in gradle.properties and open PR with version bump
+* After PR is merged, draft_release GH action runs
+  * Generates draft release with auto-generated release notes (from PRs)
+* Developer edits release notes in draft release (from GitHub Web UI)
+* Developer publishes release
+* Release GH action runs 
+  * picks up changelog from GH release body
+  * updates plugin.xml (:patchPluginXml gradle task - which runs as part of :publishPlugin gradle task)
+  * updates changelog in CHANGELOG.md (:patchChangelog gradle task)  
+  * publishes plugin to Jetbrains marketplace
+  * creates PR with changelog entries

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = network.radicle.jetbrains
 pluginName = radicle-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.5-alpha
+pluginVersion = 0.2.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.


### PR DESCRIPTION
This way, it will become easier for developers to actually start using our plugin.