### PR TITLE
Hotfix/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,47 @@
 
 # radicle-jetbrains-plugin Changelog
 
-## [Unreleased]
+## Unreleased
 
-## [0.1.4-alpha]
+## 0.2.0 - 2022-11-02
+
+### Added
+- It's now possible to publish Git repos to Radicle, directly from your IDE !! https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/56 and https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/61
+- You can now view/manage Radicle Identities in the plugin settings and choose your active Identity - https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/43
+- Chances are you will have some frequently-used seed nodes... You can now add these in the plugin settings - https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/42
+- * Browse through projects and clone them, from the new “Radicle” section in the existing Git clone dialog - https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/45, https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/48 and https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/49
+    * Copy the `rad://` URL from the Radicle Web Client and paste it in the IDE - https://github.com/cytechmobile/radicle-jetbrains-plugin/issues/60
+
+### Changed
+- Bump remoteRobotVersion from 0.11.15 to 0.11.16 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/73
+- Bump org.jetbrains.intellij from 1.8.0 to 1.8.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/77
+- Bump org.jetbrains.intellij from 1.8.1 to 1.9.0 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/79
+- Bump junit-jupiter-api from 5.9.0 to 5.9.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/82
+- Bump org.jetbrains.kotlin.jvm from 1.7.10 to 1.7.20 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/88
+- Bump junit-jupiter-engine from 5.9.0 to 5.9.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/83
+- Bump junit-vintage-engine from 5.9.0 to 5.9.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/80
+- Bump junit-platform-launcher from 1.9.0 to 1.9.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/81
+- Bump FedericoCarboni/setup-ffmpeg from 1 to 2 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/100
+- Bump JetBrains/qodana-action from 2022.2.1 to 2022.2.3 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/110
+- Bump mockito-core from 4.8.0 to 4.8.1 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/113
+- Bump org.jetbrains.changelog from 1.3.1 to 2.0.0 by @dependabot in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/112
+
+## 0.1.4-alpha
 - Add radicle icons in the navigation bar
 - Check if the project is rad initialized before show the dialog
 - Update windows instructions
 - Update IDE version used in tests to 2022.2
 
-## [0.1.3-alpha]
+## 0.1.3-alpha
 - Show a notification every time the user open a new project, to remind him to configure the plugin path
 - Fix a bug in settings
 - Update icons
 
-## [0.1.2-alpha]
+## 0.1.2-alpha
 - Change java version from 17 to 11 and change platform version from 2022.2 to 2020.3
 
-## [0.1.1-alpha]
+## 0.1.1-alpha
+
 ### Added
 - Added Radicle menu and toolbar buttons by @JChrist in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/13
 - Added Radicle section in settings by @Stelios123 in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/19
@@ -28,9 +52,6 @@
 - Adds usage instructions by @gsaslis in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/34
 - Fix Draft Release GH Action by @gsaslis in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/35
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
-
-
-
 
 ### New Contributors
 - @gsaslis made their first contribution in https://github.com/cytechmobile/radicle-jetbrains-plugin/pull/1

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/19664.svg)](https://plugins.jetbrains.com/plugin/19664)
 
 <!-- Plugin description -->
-Integration of [Radicle](https://radicle.network) with Jetbrains IDEs.
+This plugin allows you to start using [Radicle](https://radicle.xyz) (the decentralized Code Collaboration protocol) directly from your Jetbrains IDE.
 
-Radicle enables developers to securely collaborate on software over a peer-to-peer network built on Git.
+Radicle enables developers to securely collaborate on software over a peer-to-peer network, built on top of Git,
+that provides GitHub/GitLab-like functionality (think Pull/Merge Requests, Issues, etc.).
 
-This plugin provides integration with Radicle directly within Jetbrains IDEs. 
+This plugin requires **version 0.6.1** of the `rad` Command Line Interface (CLI) tool to be installed.
+Installation instructions for `rad` are available here: [https://radicle.xyz/get-started](https://radicle.xyz/get-started)
 
-It requires the Git plugin, as well as [radicle cli](https://radicle.network/get-started.html) to be installed.
+This plugin is available under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 <!-- Plugin description end -->
 
 ## Installation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -104,9 +105,9 @@ tasks {
 
         // Get the latest available change notes from the changelog file
         changeNotes.set(provider {
-            changelog.run {
-                getOrNull(properties("pluginVersion")) ?: getLatest()
-            }.toHTML()
+            with(changelog) {
+                renderItem(getOrNull(properties("pluginVersion")) ?: getLatest(), Changelog.OutputType.HTML)
+            }
         })
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = network.radicle.jetbrains
 pluginName = radicle-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,19 +11,6 @@
     <!-- Declare the default resource location for localizing menu strings -->
     <resource-bundle>messages.RadicleBundle</resource-bundle>
 
-    <description><![CDATA[
-            This plugin allows you to start using <a href="https://radicle.xyz">Radicle</a> (the decentralized Code
-            Collaboration protocol) directly from your Jetbrains IDE.
-
-            Radicle enables developers to securely collaborate on software over a peer-to-peer network, built on top of Git,
-            that provides GitHub/GitLab-like functionality (think Pull/Merge Requests, Issues, etc.).
-
-            This plugin requires <strong>version 0.6.1</strong> the `rad` Command Line Interface (CLI) tool to be installed.
-            Installation instructions for `rad` are available here: https://radicle.xyz/get-started
-
-            This plugin is available under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>
-    ]]></description>
-
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="network.radicle.jetbrains.radiclejetbrainsplugin.services.RadicleApplicationService"/>
         <projectService serviceImplementation="network.radicle.jetbrains.radiclejetbrainsplugin.services.RadicleProjectService"/>


### PR DESCRIPTION
I found several issues in our release process:

- Changelog plugin usage needed to change from the removed `toHTML` call to `renderItem`
- Our plugin description in plugin.xml was replaced with the contents in the special section in README.md
- Changelog plugin expected a different format of Changelog.md