### PR TITLE
bump java version from 11 to 17 when preparing plugin for release

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 11
+          java-version: 17
 
       # Set environment variables
       - name: Export Properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 11
+          java-version: 17
       - name: Setup radicle-cli
         run: |
           sudo apt update


### PR DESCRIPTION
Fix used java version during draft/release, so that the plugin can be compiled and prepared