### PR TITLE
Move 0.3.0 release to alpha release stream

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = network.radicle.jetbrains
 pluginName = radicle-jetbrains-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.3.0
+pluginVersion = 0.3.0-alpha
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.


### PR DESCRIPTION
Considering the various incompatibilities between `rad` Command Line Interface version 0.6.1 and 0.7.0-dev which are being used under the hood to surface the functionality in version 0.3.0 of the plugin, we shouldn't ship this release in the stable stream.

Signed-off-by: Yorgos Saslis <yorgo@protonmail.com>