### PR TITLE
Show patch proposal info/files/commits tabs

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public class RadPatch {
     public GitRepository repo;
+    public String defaultBranch;
+    public String projectId;
     public String id;
     public String title;
     public Author author;
@@ -19,8 +21,12 @@ public class RadPatch {
     public State state;
     public List<Revision> revisions;
 
-    public RadPatch(String id, String title, Author author, String description, String target, List<String> tags,
-                    State state, List<Revision> revisions) {
+    public RadPatch() {
+        // for json
+    }
+
+    public RadPatch(
+            String id, String title, Author author, String description, String target, List<String> tags, State state, List<Revision> revisions) {
         this.id = id;
         this.title = title;
         this.author = author;
@@ -31,26 +37,16 @@ public class RadPatch {
         this.revisions = revisions;
     }
 
-    public RadPatch() {
+    public record Revision(
+            String id, String description, String base, String oid, List<String> refs,
+            List<Merge> merges, Instant timestamp, List<Discussion> discussions, List<String> reviews) { }
 
-    }
+    public record Merge(String node, String commit, Instant timestamp) { }
 
-    public record Revision(String id, String description, String base, String oid, List<String> refs,
-                           List<Merge> merges, Instant timestamp,
-                           List<Discussion> discussions, List<String> reviews) {
-    }
+    public record Discussion(String id, Author author, String body, Instant timestamp, String replyTo, List<String> reactions) { }
 
-    public record Merge(String node, String commit, Instant timestamp) {
+    public record Author(String id) { }
 
-    }
-
-    public record Discussion(String id, Author author, String body, Instant timestamp, String replyTo,
-                             List<String> reactions) {
-    }
-
-    public record Author(String id) {
-
-    }
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     public enum State {
         OPEN("Open"),

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadProject.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadProject.java
@@ -4,10 +4,16 @@ public class RadProject {
     public String id;
     public String name;
     public String description;
+    public String defaultBranch;
 
-    public RadProject(String id, String name, String description) {
+    public RadProject() {
+        // for json
+    }
+
+    public RadProject(String id, String name, String description, String defaultBranch) {
         this.id = id;
         this.name = name;
         this.description = description;
+        this.defaultBranch = defaultBranch;
     }
 }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
@@ -157,9 +157,16 @@ public class PatchProposalPanel {
         var titlePane = new BaseHtmlEditorPane();
         titlePane.setFont(titlePane.getFont().deriveFont((float) (titlePane.getFont().getSize() * 1.2)));
         titlePane.setBody(patch.title);
-        var nonOpaquePanel = new NonOpaquePanel(new MigLayout(new LC().insets("0").gridGap("0", "0").noGrid()));
-        nonOpaquePanel.add(icon, new CC().gapRight(String.valueOf(JBUIScale.scale(4))));
-        nonOpaquePanel.add(titlePane, new CC());
+        var idPane = new BaseHtmlEditorPane();
+        idPane.setFont(titlePane.getFont().deriveFont((float) (titlePane.getFont().getSize() * 0.8)));
+        idPane.setForeground(JBColor.GRAY);
+        idPane.setBody(patch.id);
+        var nonOpaquePanel = new NonOpaquePanel(new MigLayout(new LC().insets("0").gridGap("0", "0").fill().flowY()));
+        var iconAndTitlePane = new NonOpaquePanel(new MigLayout(new LC().insets("0").gridGap("0", "0").noGrid()));
+        iconAndTitlePane.add(icon, new CC().gapRight(String.valueOf(JBUIScale.scale(4))));
+        iconAndTitlePane.add(titlePane, new CC());
+        nonOpaquePanel.add(iconAndTitlePane, new CC().gapBottom(String.valueOf(UI.scale(8))));
+        nonOpaquePanel.add(idPane, new CC());
         return nonOpaquePanel;
     }
 

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
@@ -30,7 +30,6 @@ import com.intellij.util.ui.components.BorderLayoutPanel;
 import git4idea.GitCommit;
 import git4idea.changes.GitChangeUtils;
 import git4idea.history.GitHistoryUtils;
-import git4idea.repo.GitRepositoryManager;
 import icons.CollaborationToolsIcons;
 import kotlin.Unit;
 import net.miginfocom.layout.CC;
@@ -42,10 +41,9 @@ import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadPatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import javax.swing.JComponent;
-import javax.swing.JPanel;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import java.awt.BorderLayout;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -168,12 +166,7 @@ public class PatchProposalPanel {
     private JComponent branchComponent(Project project) {
         var branchPanel = new NonOpaquePanel();
         branchPanel.setLayout(new MigLayout(new LC().fillX().gridGap("0", "0").insets("0", "0", "0", "0")));
-        var currentBranch = "";
-        var gitRepoManager = GitRepositoryManager.getInstance(project);
-        if (gitRepoManager.getRepositories().size() > 0) {
-            currentBranch = gitRepoManager.getRepositories().get(0).getCurrentBranch().getName();
-        }
-        var to = createLabel(currentBranch);
+        var to = createLabel(patch.defaultBranch);
         var revision = patch.revisions.get(patch.revisions.size() - 1);
         var ref = revision.refs().get(revision.refs().size() - 1);
         var from = createLabel(ref);

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchTabController.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchTabController.java
@@ -53,5 +53,4 @@ public class PatchTabController {
     public PatchListPanel getPatchListPanel() {
         return patchListPanel;
     }
-
 }

--- a/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/clone/CloneDialogTest.java
+++ b/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/clone/CloneDialogTest.java
@@ -107,7 +107,7 @@ public class CloneDialogTest extends AbstractIT {
     @Test
     public void successCloneTest() throws InterruptedException {
         radicleProjectSettingsHandler.savePath("");
-        var radProject = new RadProject("hnrk81ky87cii8h68nedkej991c5dspazi9xy", "testName", "Test");
+        var radProject = new RadProject("hnrk81ky87cii8h68nedkej991c5dspazi9xy", "testName", "Test", "main");
         cloneDialog.projectModel.addElement(radProject);
         cloneDialog.radProjectJBList.setSelectedIndex(0);
         cloneDialog.doClone(new CheckoutProvider());
@@ -127,7 +127,7 @@ public class CloneDialogTest extends AbstractIT {
 
     @Test
     public void errorCloneTest() throws InterruptedException {
-        var radProject = new RadProject("hnr", "testName", "Test");
+        var radProject = new RadProject("hnr", "testName", "Test", "main");
         cloneDialog.projectModel.addElement(radProject);
         cloneDialog.radProjectJBList.setSelectedIndex(0);
         cloneDialog.doClone(new CheckoutProvider());


### PR DESCRIPTION
The patch proposal info tab shows information about the selected patch proposal:
- The target branch and the source branch
- The patch proposal title, id and description
Tags were skipped, since they will completely disappear when updating to the new ui.

For files/commits tabs, fixed the calculation for changed files and commits to account for all changes performed in all revisions inside the patch, using the correct git revision hashes for source/target.

Closes #131 