### PR TITLE
add support for aliases in radicle identities

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/IssueListPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/IssueListPanel.java
@@ -1,5 +1,6 @@
 package network.radicle.jetbrains.radiclejetbrainsplugin.issues;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
@@ -9,19 +10,21 @@ import kotlinx.coroutines.CoroutineScope;
 import net.miginfocom.layout.CC;
 import net.miginfocom.layout.LC;
 import net.miginfocom.swing.MigLayout;
+import network.radicle.jetbrains.radiclejetbrainsplugin.RadicleBundle;
 import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadIssue;
 import network.radicle.jetbrains.radiclejetbrainsplugin.toolwindow.ListPanel;
 
 import javax.accessibility.AccessibleContext;
-import javax.swing.ListCellRenderer;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
-import javax.swing.JLabel;
-import java.awt.Component;
+import javax.swing.ListCellRenderer;
 import java.awt.BorderLayout;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.awt.Component;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -76,13 +79,14 @@ public class IssueListPanel extends ListPanel<RadIssue, IssueListSearchValue, Is
             var assigneeFilter = searchValue.assignee;
             var loadedRadIssues = loadedData;
             List<RadIssue> filteredPatches = loadedRadIssues.stream()
-                    .filter(p -> searchFilter == null || p.author.id.contains(searchFilter) ||
+                    .filter(p -> Strings.isNullOrEmpty(searchFilter) || p.author.generateLabelText().contains(searchFilter) ||
                             p.title.contains(searchFilter))
-                    .filter(p -> projectFilter == null || p.repo.getRoot().getName().equals(projectFilter))
-                    .filter(p -> peerAuthorFilter == null || p.author.id.equals(peerAuthorFilter))
-                    .filter(p -> stateFilter == null || (p.state != null && p.state.status.equals(stateFilter)))
-                    .filter(p -> tagFilter == null || p.tags.stream().anyMatch(tag -> tag.equals(tagFilter)))
-                    .filter(p -> assigneeFilter == null || p.assignees.stream().anyMatch(tag -> tag.equals(assigneeFilter)))
+                    .filter(p -> Strings.isNullOrEmpty(projectFilter) || p.repo.getRoot().getName().equals(projectFilter))
+                    .filter(p -> Strings.isNullOrEmpty(peerAuthorFilter) || Strings.nullToEmpty(p.author.alias).equals(peerAuthorFilter) ||
+                            p.author.id.equals(peerAuthorFilter))
+                    .filter(p -> Strings.isNullOrEmpty(stateFilter) || (p.state != null && p.state.status.equals(stateFilter)))
+                    .filter(p -> Strings.isNullOrEmpty(tagFilter) || p.tags.stream().anyMatch(tag -> tag.equals(tagFilter)))
+                    .filter(p -> Strings.isNullOrEmpty(assigneeFilter) || p.assignees.stream().anyMatch(tag -> tag.equals(assigneeFilter)))
                     .collect(Collectors.toList());
             model.addAll(filteredPatches);
         }
@@ -134,12 +138,12 @@ public class IssueListPanel extends ListPanel<RadIssue, IssueListSearchValue, Is
                 title = new JLabel(issue.title);
                 issuePanel.add(title, BorderLayout.NORTH);
                 var firstDiscussion = issue.discussion.get(0);
-                var date = Date.from(firstDiscussion.timestamp);
-                var formattedDate = new SimpleDateFormat("dd/MM/yyyy").format(date);
-                var info = new JLabel("Created : " + formattedDate + " by " + issue.author.id);
+                var formattedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).format(firstDiscussion.timestamp.atZone(ZoneId.systemDefault()));
+                var info = new JLabel(RadicleBundle.message("created") + ": " + formattedDate + " " +
+                        RadicleBundle.message("by") + " " + issue.author.generateLabelText());
                 info.setForeground(JBColor.GRAY);
                 if (!issue.tags.isEmpty()) {
-                    var tags = new JLabel("Tags : " + String.join(", ", issue.tags));
+                    var tags = new JLabel(RadicleBundle.message("tags") + ": " + String.join(", ", issue.tags));
                     tags.setForeground(JBColor.GRAY);
                     issuePanel.add(tags, BorderLayout.SOUTH);
                 }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/overview/IssueComponent.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/overview/IssueComponent.java
@@ -102,7 +102,7 @@ public class IssueComponent {
             var contentPanel = new JPanel(SizeRestrictedSingleComponentLayout.Companion.constant(null, null));
             contentPanel.setOpaque(false);
             contentPanel.add(StatusMessageComponentFactory.INSTANCE.create(textHtmlEditor, StatusMessageType.WARNING));
-            mainPanel.add(createTimeLineItem(contentPanel, horizontalPanel, com.author.id, com.timestamp));
+            mainPanel.add(createTimeLineItem(contentPanel, horizontalPanel, com.author.generateLabelText(), com.timestamp));
         }
         return mainPanel;
     }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadAuthor.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadAuthor.java
@@ -1,12 +1,27 @@
 package network.radicle.jetbrains.radiclejetbrainsplugin.models;
 
+import com.google.common.base.Strings;
+
 public class RadAuthor {
     public String id;
+    public String alias;
 
     public RadAuthor() {
     }
 
     public RadAuthor(String id) {
         this.id = id;
+    }
+
+    public String generateLabelText() {
+        if (!Strings.isNullOrEmpty(alias)) {
+            return alias + " (" + id + ")";
+        }
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "{\"id\": " + id + "\", \"alias\": \"" + alias + "\"}";
     }
 }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
@@ -1,5 +1,6 @@
 package network.radicle.jetbrains.radiclejetbrainsplugin.patches;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
@@ -9,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope;
 import net.miginfocom.layout.CC;
 import net.miginfocom.layout.LC;
 import net.miginfocom.swing.MigLayout;
+import network.radicle.jetbrains.radiclejetbrainsplugin.RadicleBundle;
 import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadPatch;
 import network.radicle.jetbrains.radiclejetbrainsplugin.toolwindow.ListPanel;
 
@@ -20,8 +22,9 @@ import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -76,12 +79,13 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
              var tagFilter = patchListSearchValue.tag;
              var loadedRadPatches = loadedData;
              List<RadPatch> filteredPatches = loadedRadPatches.stream()
-                     .filter(p -> searchFilter == null || p.author.id.contains(searchFilter) ||
+                     .filter(p -> Strings.isNullOrEmpty(searchFilter) || p.author.generateLabelText().contains(searchFilter) ||
                              p.title.contains(searchFilter) || p.description.contains(searchFilter))
-                     .filter(p -> projectFilter == null || p.repo.getRoot().getName().equals(projectFilter))
-                     .filter(p -> peerAuthorFilter == null || p.author.id.equals(peerAuthorFilter))
-                     .filter(p -> stateFilter == null || (p.state != null && p.state.status.equals(stateFilter)))
-                     .filter(p -> tagFilter == null || p.tags.stream().anyMatch(tag -> tag.equals(tagFilter)))
+                     .filter(p -> Strings.isNullOrEmpty(projectFilter) || p.repo.getRoot().getName().equals(projectFilter))
+                     .filter(p -> Strings.isNullOrEmpty(peerAuthorFilter) || Strings.nullToEmpty(p.author.alias).equals(peerAuthorFilter) ||
+                             p.author.id.equals(peerAuthorFilter))
+                     .filter(p -> Strings.isNullOrEmpty(stateFilter) || (p.state != null && p.state.status.equals(stateFilter)))
+                     .filter(p -> Strings.isNullOrEmpty(tagFilter) || p.tags.stream().anyMatch(tag -> tag.equals(tagFilter)))
                      .collect(Collectors.toList());
              model.addAll(filteredPatches);
          }
@@ -133,9 +137,9 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
                 title = new JLabel(patch.title);
                 patchPanel.add(title, BorderLayout.NORTH);
                 var revision = patch.revisions.get(patch.revisions.size() - 1);
-                var date = Date.from(revision.timestamp());
-                var formattedDate = new SimpleDateFormat("dd/MM/yyyy").format(date);
-                var info = new JLabel("Created : " + formattedDate + " by " + patch.author.id);
+                var formattedDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT).format(revision.timestamp().atZone(ZoneId.systemDefault()));
+                var info = new JLabel(RadicleBundle.message("created") + ": " + formattedDate + " " +
+                        RadicleBundle.message("by") + " " + patch.author.generateLabelText());
                 info.setForeground(JBColor.GRAY);
                 patchPanel.add(info, BorderLayout.SOUTH);
                 add(patchPanel, new CC().minWidth("0").gapAfter("push"));
@@ -144,7 +148,7 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
             @Override
             public AccessibleContext getAccessibleContext() {
                 var ac = super.getAccessibleContext();
-                ac.setAccessibleName(patch.repo.getRoot().getName() + " - " + patch.author);
+                ac.setAccessibleName(patch.repo.getRoot().getName() + " - " + patch.author.generateLabelText());
                 return ac;
             }
         }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponent.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponent.java
@@ -18,6 +18,7 @@ import network.radicle.jetbrains.radiclejetbrainsplugin.RadicleBundle;
 import network.radicle.jetbrains.radiclejetbrainsplugin.actions.rad.RadAction;
 import network.radicle.jetbrains.radiclejetbrainsplugin.actions.rad.RadSelf;
 import network.radicle.jetbrains.radiclejetbrainsplugin.icons.RadicleIcons;
+import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadAuthor;
 import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadDetails;
 import network.radicle.jetbrains.radiclejetbrainsplugin.models.RadPatch;
 import network.radicle.jetbrains.radiclejetbrainsplugin.patches.PatchProposalPanel;
@@ -66,7 +67,28 @@ public class TimelineComponent {
             var radDetails = getCurrentRadDetails();
             if (radDetails != null) {
                 ApplicationManager.getApplication().invokeLater(() -> {
-                    var commentSection = createTimeLineItem(getCommentField().panel, horizontalPanel, radDetails.did, null);
+                    var self = radDetails.did;
+                    if (radPatch.author.id.equals(self)) {
+                        self = radPatch.author.generateLabelText();
+                    } else {
+                        // look for an alias in discussions
+                        RadAuthor selfAuthor = null;
+                        for (var rev : radPatch.revisions) {
+                            for (var d : rev.discussions()) {
+                                if (d.author.id.equals(self)) {
+                                    selfAuthor = d.author;
+                                    break;
+                                }
+                            }
+                            if (selfAuthor != null) {
+                                break;
+                            }
+                        }
+                        if (selfAuthor != null) {
+                            self = selfAuthor.generateLabelText();
+                        }
+                    }
+                    var commentSection = createTimeLineItem(getCommentField().panel, horizontalPanel, self, null);
                     commentPanel = commentSection;
                     timelinePanel.add(commentSection);
                 }, ModalityState.any());

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponentFactory.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponentFactory.java
@@ -64,7 +64,7 @@ public class TimelineComponentFactory {
         contentPanel.setOpaque(false);
         var horizontalPanel = getHorizontalPanel(8);
         horizontalPanel.setOpaque(false);
-        descSection = createTimeLineItem(contentPanel, horizontalPanel, patch.author.id, null);
+        descSection = createTimeLineItem(contentPanel, horizontalPanel, patch.author.generateLabelText(), null);
         return descSection;
     }
 
@@ -136,7 +136,7 @@ public class TimelineComponentFactory {
                 var contentPanel = new JPanel(SizeRestrictedSingleComponentLayout.Companion.constant(null, null));
                 contentPanel.setOpaque(false);
                 contentPanel.add(StatusMessageComponentFactory.INSTANCE.create(textHtmlEditor, StatusMessageType.WARNING));
-                mainPanel.add(createTimeLineItem(contentPanel, horizontalPanel, com.author.id, com.timestamp));
+                mainPanel.add(createTimeLineItem(contentPanel, horizontalPanel, com.author.generateLabelText(), com.timestamp));
             }
         }
         return mainPanel;

--- a/src/main/resources/messages/RadicleBundle.properties
+++ b/src/main/resources/messages/RadicleBundle.properties
@@ -116,3 +116,6 @@ fetchIssuesError=There was an error getting the issues
 fetchIssueError=There was an error getting the issue
 fetchSeedNodeError=There was an error getting the seed node information
 assignees=Assignees
+created=Created
+by=by
+tags=Tags


### PR DESCRIPTION
A radicle identity (e.g. author in patches or issues) may contain an alias. When displaying such an identity, check if we had an alias and show that as well.

Closes #271 