### PR TITLE
Keep search model after refreshes in patch/issue lists

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/IssueListPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/issues/IssueListPanel.java
@@ -31,10 +31,12 @@ import java.util.stream.Collectors;
 public class IssueListPanel extends ListPanel<RadIssue, IssueListSearchValue, IssueSearchPanelViewModel> {
     private final ListCellRenderer<RadIssue> issueListCellRenderer = new IssueListCellRenderer();
     private final IssueTabController cntrl;
+    protected IssueListSearchValue issueListSearchValue;
 
     public IssueListPanel(IssueTabController controller, Project project) {
         super(controller, project);
         this.cntrl = controller;
+        this.issueListSearchValue = getEmptySearchValueModel();
     }
 
     @Override
@@ -49,7 +51,9 @@ public class IssueListPanel extends ListPanel<RadIssue, IssueListSearchValue, Is
 
     @Override
     public IssueSearchPanelViewModel getViewModel(CoroutineScope scope) {
-        return new IssueSearchPanelViewModel(scope, new IssueSearchHistoryModel(), project);
+        var model = new IssueSearchPanelViewModel(scope, new IssueSearchHistoryModel(), project);
+        model.getSearchState().setValue(this.issueListSearchValue);
+        return model;
     }
 
     @Override
@@ -64,6 +68,7 @@ public class IssueListPanel extends ListPanel<RadIssue, IssueListSearchValue, Is
 
     @Override
     public void filterList(IssueListSearchValue searchValue) {
+        this.issueListSearchValue = searchValue;
         model.clear();
         if (loadedData == null) {
             return;

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
@@ -31,10 +31,12 @@ import java.util.stream.Collectors;
 public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, PatchSearchPanelViewModel> {
     private final PatchTabController controller;
     private final ListCellRenderer<RadPatch> patchListCellRenderer = new PatchListCellRenderer();
+    protected PatchListSearchValue patchListSearchValue;
 
     public PatchListPanel(PatchTabController ctrl, Project project) {
         super(ctrl, project);
         this.controller = ctrl;
+        this.patchListSearchValue = getEmptySearchValueModel();
     }
 
     @Override
@@ -49,7 +51,9 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
 
     @Override
     public PatchSearchPanelViewModel getViewModel(CoroutineScope scope) {
-        return new PatchSearchPanelViewModel(scope, new PatchSearchHistoryModel(), project);
+        var model = new PatchSearchPanelViewModel(scope, new PatchSearchHistoryModel(), project);
+        model.getSearchState().setValue(this.patchListSearchValue);
+        return model;
     }
 
     @Override
@@ -63,19 +67,20 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
     }
 
      @Override
-     public void filterList(PatchListSearchValue patchListSearchValue) {
+     public void filterList(PatchListSearchValue plsv) {
+        this.patchListSearchValue = plsv;
          model.clear();
          if (loadedData == null) {
              return;
          }
-         if (patchListSearchValue.getFilterCount() == 0) {
+         if (plsv.getFilterCount() == 0) {
              model.addAll(loadedData);
          } else {
-             var projectFilter = patchListSearchValue.project;
-             var searchFilter = patchListSearchValue.searchQuery;
-             var peerAuthorFilter = patchListSearchValue.author;
-             var stateFilter = patchListSearchValue.state;
-             var labelFilter = patchListSearchValue.label;
+             var projectFilter = plsv.project;
+             var searchFilter = plsv.searchQuery;
+             var peerAuthorFilter = plsv.author;
+             var stateFilter = plsv.state;
+             var labelFilter = plsv.label;
              var loadedRadPatches = loadedData;
              List<RadPatch> filteredPatches = loadedRadPatches.stream()
                      .filter(p -> Strings.isNullOrEmpty(searchFilter) || p.author.generateLabelText().contains(searchFilter) ||

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchTabController.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchTabController.java
@@ -55,8 +55,7 @@ public class PatchTabController extends TabController<RadPatch, PatchListSearchV
         final var patch = myPatchModel.getValue();
         var file = new PatchVirtualFile(myPatchModel, proposalPanel);
         var editorTabs = Arrays.stream(editorManager.getAllEditors()).filter(ed ->
-                ed.getFile() instanceof PatchVirtualFile &&
-                        ((PatchVirtualFile) ed.getFile()).getPatch().id.equals(patch.id)).toList();
+                ed.getFile() instanceof PatchVirtualFile pvf && pvf.getPatch().id.equals(patch.id)).toList();
         if (force) {
             for (var et : editorTabs) {
                 editorManager.closeFile(et.getFile());

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
@@ -51,7 +51,6 @@ public class RadicleProjectApi {
     private final Project project;
 
     protected Cache<String, Session> sessions;
-    protected SeedNode seedNode;
 
     public RadicleProjectApi(Project project) {
         this(project, HttpClientBuilder.create().build());
@@ -554,13 +553,9 @@ public class RadicleProjectApi {
     }
 
     protected SeedNode getSeedNode() {
-        if (seedNode != null) {
-            return seedNode;
-        }
         var sh = new RadicleProjectSettingsHandler(project);
         var settings = sh.loadSettings();
-        seedNode = settings.getSeedNode();
-        return seedNode;
+        return settings.getSeedNode();
     }
 
     protected String getHttpNodeUrl() {


### PR DESCRIPTION
Initialize the patch/issue list search model using any possible last value.
This allows the search model to persist through refreshes, as it is re-initialized with the same filters.
Closes #344 

![refresh_filters](https://github.com/cytechmobile/radicle-jetbrains-plugin/assets/1916797/331b6e92-deca-4f6f-8cc3-470c1caf1dfb)