### PR TITLE
Fix Radicle Tool Window Icon size

### DIFF
--- a/src/main/resources/icons/rad_tool_window.svg
+++ b/src/main/resources/icons/rad_tool_window.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24px" height="24px" viewBox="0 0 24 24" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="13px" height="13px" viewBox="0 0 24 24" version="1.1">
 <g id="surface1">
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(33.333333%,33.333333%,100%);fill-opacity:1;" d="M 4.363281 0 L 6.546875 0 L 6.546875 2.183594 L 4.363281 2.183594 Z M 17.453125 0 L 19.636719 0 L 19.636719 2.183594 L 17.453125 2.183594 Z M 6.546875 2.183594 L 8.726562 2.183594 L 8.726562 4.363281 L 6.546875 4.363281 Z M 15.273438 2.183594 L 17.453125 2.183594 L 17.453125 4.363281 L 15.273438 4.363281 Z M 6.546875 4.363281 L 8.726562 4.363281 L 8.726562 6.546875 L 6.546875 6.546875 Z M 6.546875 4.363281 "/>
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(20%,20%,86.666667%);fill-opacity:1;" d="M 8.726562 4.363281 L 10.910156 4.363281 L 10.910156 6.546875 L 8.726562 6.546875 Z M 8.726562 4.363281 "/>

--- a/src/main/resources/icons/rad_tool_window_new_ui.svg
+++ b/src/main/resources/icons/rad_tool_window_new_ui.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24px" height="24px" viewBox="0 0 24 24" version="1.1">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="13px" height="13px" viewBox="0 0 24 24" version="1.1">
 <g id="surface1">
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(33.333333%,33.333333%,100%);fill-opacity:1;" d="M 4.363281 0 L 6.546875 0 L 6.546875 2.183594 L 4.363281 2.183594 Z M 17.453125 0 L 19.636719 0 L 19.636719 2.183594 L 17.453125 2.183594 Z M 6.546875 2.183594 L 8.726562 2.183594 L 8.726562 4.363281 L 6.546875 4.363281 Z M 15.273438 2.183594 L 17.453125 2.183594 L 17.453125 4.363281 L 15.273438 4.363281 Z M 6.546875 4.363281 L 8.726562 4.363281 L 8.726562 6.546875 L 6.546875 6.546875 Z M 6.546875 4.363281 "/>
 <path style=" stroke:none;fill-rule:nonzero;fill:rgb(20%,20%,86.666667%);fill-opacity:1;" d="M 8.726562 4.363281 L 10.910156 4.363281 L 10.910156 6.546875 L 8.726562 6.546875 Z M 8.726562 4.363281 "/>


### PR DESCRIPTION
According to the tool window specifications, the tool window icon must be 13x13 pixels size:
Copying from `com.intellij.openapi.wm.ToolWindowEP` javadoc for `icon` field:
```
The resource path of the icon displayed on the toolwindow button. Toolwindow icons must have the size of 13x13 pixels.
```

Closes #345