### PR TITLE
Disable patch status edit button

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
@@ -124,6 +124,10 @@ public class RadPatch {
         return RadAction.isSuccess(output);
     }
 
+    public boolean isMerged() {
+        return this.state.status.equals(State.MERGED.status);
+    }
+
     @Override
     public String toString() {
         try {

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
@@ -273,6 +273,12 @@ public class PatchProposalPanel {
         public record State(String status, String label) {
         }
 
+        public StateSelect() {
+            if (patch.isMerged()) {
+                disableEditButton(RadicleBundle.message("patchStateChangeTooltip"));
+            }
+        }
+
         public static class StateRender extends SelectionListCellRenderer<State> {
 
             @Override

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/toolwindow/LabeledListPanelHandle.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/toolwindow/LabeledListPanelHandle.java
@@ -1,5 +1,6 @@
 package network.radicle.jetbrains.radiclejetbrainsplugin.toolwindow;
 
+import com.google.common.base.Strings;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -89,6 +90,13 @@ public abstract  class LabeledListPanelHandle<T> {
         jbPopup.showUnderneathOf(parent);
         listener = popUpBuilder.getListener();
         return result;
+    }
+
+    public void disableEditButton(String tooltip) {
+        if (!Strings.isNullOrEmpty(tooltip)) {
+            editButton.setTooltip(tooltip);
+        }
+        editButton.setEnabled(false);
     }
 
     public void updateValues() {

--- a/src/main/resources/messages/RadicleBundle.properties
+++ b/src/main/resources/messages/RadicleBundle.properties
@@ -164,4 +164,5 @@ findRemoteErrorDesc=Unable to find rad remote
 newPatch=New Patch
 issueCommentError=There was an error editing patch comment
 fetching=Fetching
+patchStateChangeTooltip=You cannot change the state of a merged patch proposal
 errorParsingSession=There was an error parsing the session

--- a/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/TimelineTest.java
+++ b/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/TimelineTest.java
@@ -471,6 +471,21 @@ public class TimelineTest extends AbstractIT {
     }
 
     @Test
+    public void testStateEditButtonWithMergedPatch() {
+        patch.state = RadPatch.State.MERGED;
+        patchTabController.createPatchProposalPanel(patch);
+        var panel = patchTabController.getPatchProposalJPanel();
+        var ef = UIUtil.findComponentOfType(panel, OnePixelSplitter.class);
+        var actionPanel = ef.getSecondComponent();
+        var components = actionPanel.getComponents();
+        var statePanel = (NonOpaquePanel) components[1];
+        // Assert that if the patch has status merged then the edit button is disable
+        var openPopupButton = (InlineIconButton) UIUtil.findComponentOfType(statePanel, InlineIconButton.class);
+        assertThat(openPopupButton.isEnabled()).isFalse();
+        assertThat(openPopupButton.getTooltip()).isEqualTo(RadicleBundle.message("patchStateChangeTooltip"));
+    }
+
+    @Test
     public void changeStateTest() throws InterruptedException {
         var patchProposalPanel = patchTabController.getPatchProposalPanel();
         var panel = patchTabController.getPatchProposalJPanel();


### PR DESCRIPTION
Disable patch status edit functionality if the patch is merged 
closes #395 