### PR TITLE
fix: Patch overview panel

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/models/RadPatch.java
@@ -28,7 +28,6 @@ public class RadPatch {
     public String id;
     public String title;
     public RadAuthor author;
-    public String description;
     public String target;
     public List<String> labels;
     public State state;
@@ -39,13 +38,12 @@ public class RadPatch {
     }
 
     public RadPatch(
-            String id, String projectId, String title, RadAuthor author, String description, String target,
+            String id, String projectId, String title, RadAuthor author, String target,
             List<String> labels, State state, List<Revision> revisions) {
         this.id = id;
         this.projectId = projectId;
         this.title = title;
         this.author = author;
-        this.description = description;
         this.target = target;
         this.labels = labels;
         this.state = state;
@@ -61,7 +59,6 @@ public class RadPatch {
         this.id = other.id;
         this.title = other.title;
         this.author = other.author;
-        this.description = other.description;
         this.target = other.target;
         this.labels = other.labels;
         this.state = other.state;
@@ -119,7 +116,7 @@ public class RadPatch {
 
     public record Revision(
             String id, String description, String base, String oid, List<String> refs,
-            List<Merge> merges, Instant timestamp, List<RadDiscussion> discussions, List<Object> reviews) { }
+            List<Merge> merges, Instant timestamp, List<RadDiscussion> discussions, List<Object> reviews, RadAuthor author) { }
 
     public record Merge(String node, String commit, Instant timestamp) { }
 

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanel.java
@@ -85,7 +85,7 @@ public class PatchListPanel extends ListPanel<RadPatch, PatchListSearchValue, Pa
              var loadedRadPatches = loadedData;
              List<RadPatch> filteredPatches = loadedRadPatches.stream()
                      .filter(p -> Strings.isNullOrEmpty(searchFilter) || p.author.generateLabelText().contains(searchFilter) ||
-                             p.title.contains(searchFilter) || (Strings.nullToEmpty(p.description).contains(searchFilter)))
+                             p.title.contains(searchFilter) || (Strings.nullToEmpty(p.getLatestRevision().description()).contains(searchFilter)))
                      .filter(p -> Strings.isNullOrEmpty(projectFilter) || p.repo.getRoot().getName().equals(projectFilter))
                      .filter(p -> Strings.isNullOrEmpty(peerAuthorFilter) || Strings.nullToEmpty(p.author.alias).equals(peerAuthorFilter) ||
                              p.author.id.equals(peerAuthorFilter))

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchProposalPanel.java
@@ -175,7 +175,7 @@ public class PatchProposalPanel {
     private JComponent descriptionComponent() {
         var titlePane = new BaseHtmlEditorPane();
         titlePane.setFont(titlePane.getFont().deriveFont((float) (titlePane.getFont().getSize() * 1.2)));
-        titlePane.setBody(Strings.nullToEmpty(patch.description));
+        titlePane.setBody(Strings.nullToEmpty(patch.getLatestRevision().description()));
         var nonOpaquePanel = new NonOpaquePanel(new MigLayout(new LC().insets("0").gridGap("0", "0").noGrid()));
         nonOpaquePanel.add(titlePane, new CC().gapBottom(String.valueOf(UI.scale(8))));
         final var viewTimelineLink = new ActionLink(RadicleBundle.message("view.timeline"), e -> {

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponentFactory.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/timeline/TimelineComponentFactory.java
@@ -75,7 +75,7 @@ public class TimelineComponentFactory {
     }
 
     public JComponent createDescSection() {
-        var description = !Strings.isNullOrEmpty(patch.description) ? patch.description :
+        var description = !Strings.isNullOrEmpty(patch.getLatestRevision().description()) ? patch.getLatestRevision().description() :
                 RadicleBundle.message("noDescription");
         var editorPane = new MarkDownEditorPaneFactory(description, patch.project, patch.projectId, file);
         descSection = Utils.descriptionPanel(editorPane, patch.project);
@@ -106,18 +106,13 @@ public class TimelineComponentFactory {
                 }
                 for (var rev : patch.revisions) {
                     var contentPanel = getVerticalPanel(4);
-                    var textHtmlEditor = new BaseHtmlEditorPane();
-                    var description = !Strings.isNullOrEmpty(rev.description()) ? rev.description() :
-                            RadicleBundle.message("noDescription");
-                    textHtmlEditor.setBody(description);
-                    contentPanel.add(textHtmlEditor);
                     var patchCommits = groupedCommits.get(rev.id());
                     Collections.reverse(patchCommits);
-                    contentPanel.add(StatusMessageComponentFactory.INSTANCE.create(createCommitsSection(patchCommits), StatusMessageType.INFO));
                     contentPanel.setOpaque(false);
                     var horizontalPanel = getHorizontalPanel(8);
                     horizontalPanel.setOpaque(false);
-                    var item = createTimeLineItem(contentPanel, horizontalPanel, "Revision " + rev.id() + " was published",
+                    var revAuthor = !Strings.isNullOrEmpty(rev.author().alias) ? rev.author().alias : rev.author().id;
+                    var item = createTimeLineItem(contentPanel, horizontalPanel, RadicleBundle.message("revisionPublish", rev.id(), revAuthor),
                             rev.timestamp());
                     mainPanel.add(item);
                     mainPanel.add(createCommentSection(List.of(rev)));

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
@@ -568,7 +568,7 @@ public class RadicleProjectApi {
             var patchReq = new HttpPatch(getHttpNodeUrl() + "/api/v1/projects/" + patch.projectId + "/patches/" + patch.id);
             patchReq.setHeader("Authorization", "Bearer " + session.sessionId);
             var patchEditData = Map.of("type", "edit", "target", "delegates", "title",
-                    Strings.nullToEmpty(patch.title), "description", Strings.nullToEmpty(patch.description));
+                    Strings.nullToEmpty(patch.title));
             var json = MAPPER.writeValueAsString(patchEditData);
             patchReq.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
             var resp = makeRequest(patchReq, RadicleBundle.message("patchTitleError"));

--- a/src/main/resources/messages/RadicleBundle.properties
+++ b/src/main/resources/messages/RadicleBundle.properties
@@ -180,3 +180,4 @@ mergePatchErrorStashChanges=There were changed files in your repository and ther
 mergePatchErrorCheckoutDefaultBranch=There was an error while trying to checkout the repository default branch: {0}
 mergePatchErrorMerge=There was an error while merging the patch to your local default branch {0}
 mergePatchErrorPush=There was an error while trying to push your changes to the remote. The patch was merged to your local default branch {0}, so you need to manually push your changes to the remote
+revisionPublish=Revision {0} was published by {1}

--- a/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanelTest.java
+++ b/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchListPanelTest.java
@@ -20,6 +20,7 @@ import org.junit.runners.JUnit4;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -274,14 +275,13 @@ public class PatchListPanelTest extends AbstractIT {
 
     public static List<RadPatch> getTestPatches() {
         var revision = new RadPatch.Revision("testRevision", "testDescription", "", "",
-                List.of(), List.of(), Instant.now(), List.of(), List.of());
+                List.of(), List.of(), Instant.now(), List.of(), List.of(), new RadAuthor(UUID.randomUUID().toString()));
 
-        var radPatch = new RadPatch("c5df12", "test-rad-project", "testPatch", new RadAuthor(AUTHOR), "testDesc", "testTarget",
+        var radPatch = new RadPatch("c5df12", "test-rad-project", "testPatch", new RadAuthor(AUTHOR), "testTarget",
                 List.of("tag1", "tag2"), RadPatch.State.OPEN, List.of(revision));
 
         var radPatch2 = new RadPatch("c4d12", "test-rad-project-second", "secondProposal", new RadAuthor(AUTHOR1),
-                "My description", "testTarget", List.of("firstTag", "secondTag", "tag1"),
-                RadPatch.State.DRAFT, List.of(revision));
+                "testTarget", List.of("firstTag", "secondTag", "tag1"), RadPatch.State.DRAFT, List.of(revision));
         patches = List.of(radPatch, radPatch2);
         return patches;
     }

--- a/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/TimelineTest.java
+++ b/src/test/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/TimelineTest.java
@@ -117,7 +117,6 @@ public class TimelineTest extends AbstractIT {
                 if (map.get("type").equals("edit")) {
                     //patch
                     assertThat(map.get("target")).isEqualTo("delegates");
-                    assertThat(map.get("description")).isEqualTo(patch.description);
                     assertThat(map.get("type")).isEqualTo("edit");
                     assertThat(map.get("title")).isEqualTo(patch.title);
                 } else if (map.get("type").equals("label") || map.get("type").equals("lifecycle") || map.get("type").equals("revision.comment.react") ||
@@ -560,7 +559,8 @@ public class TimelineTest extends AbstractIT {
         for (var el : elements) {
             timeline += el.getText();
         }
-        assertThat(timeline).contains(patch.description);
+        var latestRevision = patch.revisions.get(patch.revisions.size() - 1);
+        assertThat(timeline).contains(latestRevision.description());
     }
 
     @Test
@@ -725,7 +725,7 @@ public class TimelineTest extends AbstractIT {
         var secondDiscussion = createDiscussion("321", "321", secondComment + txtEmbedMarkDown + imgEmbedMarkDown, List.of(txtEmbed, imgEmbed));
         var firstRev = createRevision("testRevision1", "testRevision1", firstCommit, firstDiscussion);
         var secondRev = createRevision("testRevision2", "testRevision1", secondCommit, secondDiscussion);
-        var myPatch = new RadPatch("c5df12", RAD_PROJECT_ID, "testPatch", new RadAuthor(AUTHOR), "testDesc",
+        var myPatch = new RadPatch("c5df12", RAD_PROJECT_ID, "testPatch", new RadAuthor(AUTHOR),
                 "testTarget", List.of("tag1", "tag2"), RadPatch.State.OPEN, List.of(firstRev, secondRev));
         myPatch.project = getProject();
         myPatch.repo = firstRepo;
@@ -747,7 +747,7 @@ public class TimelineTest extends AbstractIT {
         var discussions = new ArrayList<RadDiscussion>();
         discussions.add(discussion);
         return new RadPatch.Revision(id, description, base, commit.getId().asString(),
-                List.of("branch"), List.of(), Instant.now(), discussions, List.of());
+                List.of("branch"), List.of(), Instant.now(), discussions, List.of(), new RadAuthor(UUID.randomUUID().toString()));
     }
 
     private RadDiscussion createDiscussion(String id, String authorId, String body, List<Embed> embedList) {


### PR DESCRIPTION
Remove commits and revision description from patch overview page. Show only the revision id, revision author and the date/time that the revision was created