### PR TITLE
fix(auth): unencrypted identities

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/IdentityDialog.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/IdentityDialog.java
@@ -52,6 +52,8 @@ public class IdentityDialog extends DialogWrapper {
             aliasField.setVisible(false);
             aliasLabel.setVisible(false);
         }
+        var isFormValid =  !aliasField.getText().isEmpty() || !aliasField.isVisible();
+        setOKActionEnabled(isFormValid);
         return super.showAndGet();
     }
 
@@ -77,21 +79,14 @@ public class IdentityDialog extends DialogWrapper {
 
     protected void init() {
         super.init();
-        var isFormValid =  !passphraseField.getText().isEmpty();
-        setOKActionEnabled(isFormValid);
         var textFieldListener = new TextFieldListener();
-        passphraseField.getDocument().addDocumentListener(textFieldListener);
         aliasField.getDocument().addDocumentListener(textFieldListener);
     }
 
     public class TextFieldListener extends DocumentAdapter {
         @Override
         protected void textChanged(@NotNull DocumentEvent e) {
-            if (passphraseField.getText().isEmpty() || (aliasField.getText().isEmpty() && aliasField.isVisible())) {
-                setOKActionEnabled(false);
-            } else {
-                setOKActionEnabled(true);
-            }
+            setOKActionEnabled(!aliasField.getText().isEmpty() || !aliasField.isVisible());
         }
     }
 }


### PR DESCRIPTION
In radicle, when the passphrase is empty, the key is unencrypted.

In our plugin, we always forced a non-empty passphrase.