### PR TITLE
fix(RadicleToolWindow): Multiple radicle toolwindows

### DIFF
--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/PublishDialog.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/dialog/PublishDialog.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.ClientProperty;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.components.JBTextArea;
 import git4idea.repo.GitRepository;
@@ -28,6 +29,8 @@ import javax.swing.event.DocumentEvent;
 import java.awt.Component;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import static network.radicle.jetbrains.radiclejetbrainsplugin.toolwindow.RadicleToolWindow.RAD_REPOS_KEY;
 
 public class PublishDialog extends DialogWrapper {
     private JPanel contentPane;
@@ -77,8 +80,10 @@ public class PublishDialog extends DialogWrapper {
                     if (radToolWindow == null || radToolWindow.isAvailable()) {
                         return;
                     }
-                    ApplicationManager.getApplication().invokeLater(() ->
-                            radToolWindow.setAvailable(true), ModalityState.any());
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        ClientProperty.put(radToolWindow.getComponent(), RAD_REPOS_KEY, List.of(repo));
+                        radToolWindow.setAvailable(true);
+                    }, ModalityState.any());
                 }
             }
         });

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchSearchHistoryModel.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/patches/PatchSearchHistoryModel.java
@@ -26,6 +26,6 @@ public class PatchSearchHistoryModel implements ReviewListSearchHistoryModel<Pat
     @NotNull
     @Override
     public List<PatchListSearchValue> getHistory() {
-        return null;
+        return List.of();
     }
 }

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/services/RadicleProjectApi.java
@@ -493,13 +493,8 @@ public class RadicleProjectApi {
     }
 
     public Map<String, Object> getProjectInfo(String projectId, GitRepository repo) {
-        var session = createAuthenticatedSession();
-        if (session == null) {
-            return null;
-        }
         try {
             var req = new HttpGet(getHttpNodeUrl() + "/api/v1/projects/" + projectId);
-            req.setHeader("Authorization", "Bearer " + session.sessionId);
             var resp = makeRequest(req, RadicleBundle.message("fetchProjectError"));
             if (!resp.isSuccess()) {
                 logger.warn("Unable to get project information, projectId:{} repo:{} resp:{}", projectId, repo, resp);

--- a/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/toolwindow/RadicleToolWindow.java
+++ b/src/main/java/network/radicle/jetbrains/radiclejetbrainsplugin/toolwindow/RadicleToolWindow.java
@@ -2,16 +2,18 @@ package network.radicle.jetbrains.radiclejetbrainsplugin.toolwindow;
 
 import com.intellij.dvcs.repo.VcsRepositoryMappingListener;
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vcs.changes.ui.VcsToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import com.intellij.openapi.wm.impl.content.ToolWindowContentUi;
-import com.intellij.ui.content.Content;
+import com.intellij.ui.ClientProperty;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.ui.content.ContentManagerListener;
@@ -23,99 +25,150 @@ import network.radicle.jetbrains.radiclejetbrainsplugin.issues.IssueTabControlle
 import network.radicle.jetbrains.radiclejetbrainsplugin.patches.PatchTabController;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.JPanel;
-import java.util.ArrayList;
 import java.util.List;
 import static com.intellij.dvcs.repo.VcsRepositoryManager.VCS_REPOSITORY_MAPPING_UPDATED;
 
 public class RadicleToolWindow extends VcsToolWindowFactory {
+    public static final String TOOL_WINDOW_NAME = "Radicle";
+    public static final Key<List<GitRepository>> RAD_REPOS_KEY = Key.create("RAD_REPOS");
+    public static final Key<Boolean> ISSUE_LIST_INITIALIZED_KEY = Key.create("ISSUE_LIST_INITIALIZED");
+    public ToolWindow myToolWindow;
     public static String id;
-    private List<GitRepository> gitRepos = new ArrayList<>();
     public ToolWindowManagerListener toolWindowManagerListener;
     public PatchTabController patchTabController;
     public IssueTabController issueTabController;
-    public ContentManager contentManager;
-    private Content issueContent;
-    private Content patchContent;
-    private boolean isListInitialized = false;
-    private boolean isEnable = false;
+    public enum Action {
+        ADD, REFRESH
+    }
 
     @Override
     public void init(@NotNull ToolWindow window) {
         super.init(window);
         id = window.getId();
-        //Workaround at activating toolwindow content and check for available radicle repos
-        window.getContentManager();
-    }
-
-    @Override
-    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
-        toolWindow.getComponent().putClientProperty(ToolWindowContentUi.HIDE_ID_LABEL, "true");
-        contentManager = toolWindow.getContentManager();
-        issueContent = toolWindow.getContentManager().getFactory().createContent(new JPanel(null), RadicleBundle.message("issues"), false);
-        patchContent = toolWindow.getContentManager().getFactory().createContent(new JPanel(null), RadicleBundle.message("patches"), false);
-
-        patchContent.setDisposer(Disposer.newDisposable(toolWindow.getDisposable(), "RadiclePatchProposalsContent"));
-        issueContent.setDisposer(Disposer.newDisposable(toolWindow.getDisposable(), "RadicleIssueContent"));
-        toolWindowManagerListener = new ToolWindowManagerListener() {
-            @Override
-            public void toolWindowShown(@NotNull ToolWindow shownToolWindow) {
-                if (toolWindow == shownToolWindow && toolWindow.isVisible() && contentManager.isEmpty()) {
-                    contentManager.addContent(patchContent);
-                    contentManager.addContent(issueContent);
-                    patchTabController = new PatchTabController(patchContent, project);
-                    patchTabController.createPanel();
-                    issueTabController = new IssueTabController(issueContent, project);
-                    toolWindow.setTitleActions(List.of(new AnAction(AllIcons.General.Add) {
-                        @Override
-                        public void actionPerformed(@NotNull AnActionEvent e) {
-                            if (contentManager.isSelected(patchContent)) {
-                                patchTabController.createNewPatchPanel(gitRepos);
-                            } else if (contentManager.isSelected(issueContent)) {
-                                issueTabController.createNewIssuePanel();
-                            }
-                        }
-                    }, new AnAction(AllIcons.Actions.Refresh) {
-                        @Override
-                        public void actionPerformed(@NotNull AnActionEvent e) {
-                            if (contentManager.isSelected(patchContent)) {
-                                patchTabController.createPanel();
-                            } else if (contentManager.isSelected(issueContent)) {
-                                issueTabController.createPanel();
-                            }
-                        }
-                    }));
-                    contentManager.addContentManagerListener(new ContentManagerListener() {
-                        @Override
-                        public void selectionChanged(@NotNull ContentManagerEvent event) {
-                            if (contentManager.isSelected(issueContent) && issueTabController != null && !isListInitialized) {
-                                issueTabController.createPanel();
-                                isListInitialized = true;
-                            }
-                        }
-                    });
-                }
-            }
-        };
-
-        project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, toolWindowManagerListener);
-        project.getMessageBus().connect().subscribe(VCS_REPOSITORY_MAPPING_UPDATED, (VcsRepositoryMappingListener) () -> {
-            var gitRepoManager = GitRepositoryManager.getInstance(project);
+        var connection = window.getProject().getMessageBus().connect(window.getDisposable());
+        connection.subscribe(VCS_REPOSITORY_MAPPING_UPDATED, (VcsRepositoryMappingListener) () -> {
+            var gitRepoManager = GitRepositoryManager.getInstance(window.getProject());
             var repos = gitRepoManager.getRepositories();
-            ApplicationManager.getApplication().executeOnPooledThread(() -> {
-                var radInited = RadAction.getInitializedReposWithNodeConfigured(repos, false);
-                gitRepos = radInited;
-                if (!radInited.isEmpty()) {
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        toolWindow.setAvailable(true);
-                        isEnable = true;
-                    });
-                }
-            });
+            var radInited = RadAction.getInitializedReposWithNodeConfigured(repos, false);
+            if (!radInited.isEmpty()) {
+                ClientProperty.put(window.getComponent(), RAD_REPOS_KEY, radInited);
+                ApplicationManager.getApplication().invokeLater(() -> window.setAvailable(true));
+            }
         });
     }
 
     @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        myToolWindow = toolWindow;
+        toolWindow.getComponent().putClientProperty(ToolWindowContentUi.HIDE_ID_LABEL, "true");
+        toolWindowManagerListener = new ToolWindowManagerListener() {
+            @Override
+            public void toolWindowShown(@NotNull ToolWindow shownToolWindow) {
+                if (toolWindow == shownToolWindow && toolWindow.isVisible() && toolWindow.getContentManager().isEmpty()) {
+                    var contentManager = toolWindow.getContentManager();
+                    var issueContent = contentManager.getFactory().createContent(new JPanel(null), RadicleBundle.message("issues"), false);
+                    var patchContent = contentManager.getFactory().createContent(new JPanel(null), RadicleBundle.message("patches"), false);
+                    patchContent.setDisposer(Disposer.newDisposable(toolWindow.getDisposable(), "RadiclePatchProposalsContent"));
+                    issueContent.setDisposer(Disposer.newDisposable(toolWindow.getDisposable(), "RadicleIssueContent"));
+                    contentManager.addContent(patchContent);
+                    contentManager.addContent(issueContent);
+                    patchTabController = new PatchTabController(patchContent, project);
+                    patchTabController.createPanel();
+                    var toolbarActions = List.of(new AddAction(), new RefreshAction());
+                    toolWindow.setTitleActions(toolbarActions);
+                    contentManager.addContentManagerListener(new ContentListener(toolWindow));
+                }
+            }
+        };
+        project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, toolWindowManagerListener);
+    }
+
+    @Override
     public boolean isAvailable(@NotNull Project project) {
-        return isEnable;
+       return false;
+    }
+
+    public ContentManager getContentManager() {
+        return myToolWindow.getContentManager();
+    }
+
+    public class ContentListener implements ContentManagerListener {
+        private final ToolWindow toolWindow;
+
+        public ContentListener(ToolWindow toolWindow) {
+            this.toolWindow = toolWindow;
+        }
+
+        @Override
+        public void selectionChanged(@NotNull ContentManagerEvent event) {
+            var contentManager = toolWindow.getContentManager();
+            var issueContent = contentManager.getContent(1);
+            if (issueContent == null) {
+                return;
+            }
+            var myInitialized = ClientProperty.get(toolWindow.getComponent(), ISSUE_LIST_INITIALIZED_KEY);
+            if (contentManager.isSelected(issueContent) && myInitialized == null) {
+                issueTabController = new IssueTabController(issueContent, toolWindow.getProject());
+                issueTabController.createPanel();
+                ClientProperty.put(toolWindow.getComponent(), ISSUE_LIST_INITIALIZED_KEY, true);
+            }
+        }
+    }
+
+    private static void handleAction(@NotNull AnActionEvent e, Action action) {
+        if (e.getProject() == null) {
+            return;
+        }
+        var toolWindow = ToolWindowManager.getInstance(e.getProject()).getToolWindow(TOOL_WINDOW_NAME);
+        if (toolWindow == null) {
+            return;
+        }
+        var contentManager = toolWindow.getContentManager();
+        var patchContent = contentManager.getContent(0);
+        var issueContent = contentManager.getContent(1);
+        if (patchContent == null || issueContent == null) {
+            return;
+        }
+        // Patch tab selected
+        if (contentManager.isSelected(patchContent)) {
+            var patchTabController = new PatchTabController(patchContent, e.getProject());
+            if (action == Action.ADD) {
+                var repos = ClientProperty.get(toolWindow.getComponent(), RAD_REPOS_KEY);
+                patchTabController.createNewPatchPanel(repos);
+            } else if (action == Action.REFRESH) {
+                patchTabController.createPanel();
+            }
+        }
+        // Issue tab selected
+        if (contentManager.isSelected(issueContent)) {
+            var issueTabController = new IssueTabController(issueContent, e.getProject());
+            if (action == Action.ADD) {
+                issueTabController.createNewIssuePanel();
+            } else if (action == Action.REFRESH) {
+                issueTabController.createPanel();
+            }
+        }
+    }
+
+    private static class AddAction extends DumbAwareAction {
+        public AddAction() {
+            super(AllIcons.General.Add);
+        }
+
+        @Override
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            handleAction(e, Action.ADD);
+        }
+    }
+
+    private static class RefreshAction extends DumbAwareAction {
+        public RefreshAction() {
+            super(AllIcons.Actions.Refresh);
+        }
+
+        @Override
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            handleAction(e, Action.REFRESH);
+        }
     }
 }


### PR DESCRIPTION
1) Some elements of the Radicle Tool Window appear on the left side of the IDE, while some appear on the right. (Fixed) 
2) When the user clicks on the issue tab, they get an empty content panel. (Fixed) 
3) When the user opens IntelliJ IDEA, sometimes they get an error message stating that the project is not rad initialized. (Fixed)
4) When the user clicks on the refresh or add button, they interact with the other tool window from the second instance of Intellij IDEA. (Fixed) 
5) When the user clicks on the "Add Patch" button, the repositories passed are from the second instance of IntelliJ IDEA. (Fixed)